### PR TITLE
Leave suggestion on ConstructorOfATypedSvelteComponent

### DIFF
--- a/packages/svelte2tsx/svelte-shims.d.ts
+++ b/packages/svelte2tsx/svelte-shims.d.ts
@@ -295,7 +295,13 @@ declare type ATypedSvelteComponent = {
     $on(event: string, handler: ((e: any) => any) | null | undefined): () => void;
 }
 /**
- * Ambient type only used for intellisense, DO NOT USE IN YOUR PROJECT
+ * Ambient type only used for intellisense, DO NOT USE IN YOUR PROJECT.
+ * 
+ * If you're looking for the type of a Svelte Component, use `SvelteComponentTyped` instead:
+ *
+ * ```ts
+ * import type { SvelteComponentTyped } from "svelte";
+ * ```
  */
 declare type ConstructorOfATypedSvelteComponent = new (args: {target: any, props?: any}) => ATypedSvelteComponent
 declare function __sveltets_2_ensureComponent<T extends ConstructorOfATypedSvelteComponent | null | undefined>(type: T): NonNullable<T>;


### PR DESCRIPTION
As I've asked [in this post](https://stackoverflow.com/questions/74629272/how-can-i-type-a-component-export/74629334#74629334), there was no hint or warning that could have lead me to finding SvelteComponentTyped, so I wanted to leave a warning for any other users.